### PR TITLE
feature :토큰 자동 재발급

### DIFF
--- a/src/component/TopBar.js
+++ b/src/component/TopBar.js
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import axiosInstance from "../component/jwt.js";
 import "../css/TopBar.css";
 import logo from "../images/logo.png"
-
 import { Dialog, Disclosure, Popover, Transition } from '@headlessui/react'
 import {
   ArrowPathIcon,
@@ -15,7 +14,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { ChevronDownIcon, PhoneIcon, PlayCircleIcon } from '@heroicons/react/20/solid'
-
+import { postRefreshToken } from "../component/jwt.js";
 
 
 
@@ -28,22 +27,24 @@ export default function TopBar() {
     const accessToken = localStorage.getItem("accessToken");
     if (accessToken) {
       setIsLoggedIn(true);
-      axiosInstance
-        .get("/user/role", {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
+      axiosInstance.get("/user/role", {
+        headers : {
+          Authorization: `Bearer ${localStorage.getItem('accessToken')}`
+      }
         })
-        .then((response) => {
+        .then(async (response) => {
           setRole(response.data.data.role);
         })
-        .catch((error) => {
-          console.error("사용자 역할 가져오기 실패:", error);
+        .catch(async (error) => {
+          console.error('요청 실패:', error);
+          const response = postRefreshToken();
+          console.log(response)
         });
     } else {
       setIsLoggedIn(false);
     }
   }, []);
+
 
   const handleLogout = () => {
     localStorage.removeItem("accessToken");

--- a/src/component/jwt.js
+++ b/src/component/jwt.js
@@ -30,4 +30,35 @@ instance.interceptors.request.use(
   }
 );
 
+export const postRefreshToken = async () => {
+  console.log(localStorage.getItem('refreshToken'))
+  const response = await instance.post('/auth/reissue',
+    {accessToken: localStorage.getItem('accessToken'),refreshToken: localStorage.getItem('refreshToken'),}
+    ,{headers: { Authorization: `Bearer ${localStorage.getItem('accessToken')}` }}
+  );
+  console.log(response);
+  if(response.data.state === 400){
+    return 
+  }
+  localStorage.setItem('accessToken', response.data.data.accessToken);
+  localStorage.setItem('refreshToken', response.data.data.refreshToken);
+  document.cookie = `accessToken=${response.data.data.accessToken}; Path=/;`;
+  document.cookie = `refreshToken=${response.data.data.refreshToken}; Path=/;`
+  return response
+}
+
+instance.interceptors.response.use(
+  async (response) => { ;return response;},
+  async(error) => { 
+    if(error.response.status === 403){
+      console.log(error,'에러')
+      const response = await postRefreshToken();
+      //instance.defaults.headers에 토큰을 저장함으로써 이후에 보내게 될 모든 요청에 엑세스 토큰이 자동으로 포함됨
+      instance.defaults.headers.common.Authorization = `Bearer ${response.data.data.accessToken}`;          
+      //config.headers에 토큰을 저장함으로써 패한 요청의 설정인 originRequest 객체에도 엑세스 토큰을 저장
+      //이전에 실패한 요청을 다시 보낼 때 기존의 요청 설정에 새로 발급받은 엑세스 토큰을 포함하여 보내야 함
+      error.config.headers.Authorization = `Bearer ${response.data.data.accessToken}`;
+      return (await axios.get(error.config.url, error.config)).data,window.location.reload();
+}})
+
 export default instance;


### PR DESCRIPTION
엑세스 토큰 시간 만료로 인해 HTTP요청 실패시
리프레시 토큰을 통해 엑세스 토큰과 리프레시 토큰을 재발급 받음

#Issues #33

# 🚀 개요
<!-- 엑세스 토큰 재발급 -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 변경사항 1 엑세스 토큰 만료로 인해 HTTP요청 실패시 토큰 재발급

## ⏳ 작업 내용
- [ ] 작업 내용 1 postRefresh함수 추가 
- [ ] 작업 내용 2 인터셉터 통해 HTTP요청 실패시 postRefresh함수 작동
- [ ] 작업 내용 3

### 📝 논의사항
<!-- 왜 서버에서는 로그아웃 상태라고 판단하는지 -->
