### PR TITLE
bug : 상품상세 페이지 하트 아이콘 수정

### DIFF
--- a/src/component/TopBar.js
+++ b/src/component/TopBar.js
@@ -14,9 +14,6 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { ChevronDownIcon, PhoneIcon, PlayCircleIcon } from '@heroicons/react/20/solid'
-import { postRefreshToken } from "../component/jwt.js";
-
-
 
 export default function TopBar() {
   let navigate = useNavigate();
@@ -34,11 +31,10 @@ export default function TopBar() {
         })
         .then(async (response) => {
           setRole(response.data.data.role);
+         localStorage.setItem('role',response.data.data.role)
         })
         .catch(async (error) => {
           console.error('요청 실패:', error);
-          const response = postRefreshToken();
-          console.log(response)
         });
     } else {
       setIsLoggedIn(false);

--- a/src/component/jwt.js
+++ b/src/component/jwt.js
@@ -55,8 +55,8 @@ instance.interceptors.response.use(
       const response = await postRefreshToken();
       //instance.defaults.headers에 토큰을 저장함으로써 이후에 보내게 될 모든 요청에 엑세스 토큰이 자동으로 포함됨
       instance.defaults.headers.common.Authorization = `Bearer ${response.data.data.accessToken}`;          
-      //config.headers에 토큰을 저장함으로써 패한 요청의 설정인 originRequest 객체에도 엑세스 토큰을 저장
-      //이전에 실패한 요청을 다시 보낼 때 기존의 요청 설정에 새로 발급받은 엑세스 토큰을 포함하여 보내야 함
+      //config.headers에 토큰을 저장함으로써 실패한 요청에도 엑세스 토큰을 저장
+      //이전에 실패한 요청을 다시 보낼 때 기존의 설정에 새로 발급받은 엑세스 토큰을 포함하여 보내야 함
       error.config.headers.Authorization = `Bearer ${response.data.data.accessToken}`;
       return (await axios.get(error.config.url, error.config)).data,window.location.reload();
 }})

--- a/src/component/likeComponent.js
+++ b/src/component/likeComponent.js
@@ -7,8 +7,8 @@ function LikeComponent(props){
     return(
         <div>
             { props.likeState ? 
-            <HeartFilled onClick = {() => { props.setLikeState(prevState => !prevState); props.handleLike() }} style={{ color: 'red', fontSize: '40px', border : '2px solid black', marginTop : '4%'}} /> :
-            <HeartOutlined onClick = {() => {props.setLikeState(prevState => !prevState);props.handleLike() }} style={{ color: 'darkgrey', fontSize: '40px', border : '2px solid darkgrey', marginTop : '4%'}}/>}
+            <HeartFilled onClick = {() => { props.handleLike() }} style={{ color: 'red', fontSize: '40px', border : '2px solid black', marginTop : '4%'}} /> :
+            <HeartOutlined onClick = {() => {props.handleLike() }} style={{ color: 'darkgrey', fontSize: '40px', border : '2px solid darkgrey', marginTop : '4%'}}/>}
         </div>
     )
 }

--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -23,7 +23,7 @@ function Detail(props) {
   const [productDetailInfo, setProductDetailInfo] = useState();
   const [salePrice, setSalePrice] = useState();
   const [productLike, setProductLike] = useState();
-  const [likeState, setLikeState] = useState(false);
+  const [likeState, setLikeState] = useState();
   const Endpoint = "https://jjs-stock-bucket.s3.ap-northeast-2.amazonaws.com/";
 
   const SizeList = ["S", "M", "L", "XL"];
@@ -98,7 +98,9 @@ function Detail(props) {
 
   const handleLike = async () => {
     try {
-      if (likeState) {
+      if (localStorage.getItem('role') != 'ROLE_PURCHASER') {
+        return alert('일반 회원만 가능한 기능입니다.')
+      }else if(likeState) {
         await axiosInstance.delete(`/product/all/detail/${productid}/like`);
       } else {
         await axiosInstance.post(`/product/all/detail/${productid}/like`);
@@ -127,16 +129,21 @@ function Detail(props) {
   };
 
   useEffect(() => {
-    const LikeCheckGet = async () => {
-      try {
-        const likeStateInfo = await axiosInstance.get(
-          `/product/all/detail/${productid}/like-status`
-        );
-        setLikeState(likeStateInfo.data.data);
-      } catch (error) {
-      }
-    };
-    LikeCheckGet();
+    if(localStorage.getItem('role') == 'ROLE_PURCHASER'){
+      const LikeCheckGet = async () => {
+        try {
+          const likeStateInfo = await axiosInstance.get(
+            `/product/all/detail/${productid}/like-status`
+          );
+          setLikeState(likeStateInfo.data.data);
+        } catch (error) {
+        }
+      };
+      LikeCheckGet();
+    }else{
+      setLikeState(false);
+    }
+    
   }, []);
 
   if (!productDetailInfo) {

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -36,7 +36,6 @@ function Main(){
         fetchData();
     }, []);
 
-    
     const contentStyle = {
         height: '400px', 
         width: '100%', 
@@ -45,13 +44,13 @@ function Main(){
     };
 
     let carouselImage = ([
-        "https://i.postimg.cc/jd4cY735/3.png",
+    "https://i.postimg.cc/jd4cY735/3.png",
     "https://i.postimg.cc/zv1C9znK/1.png",
     "https://i.postimg.cc/JnX36DBR/2.png",
     "https://i.postimg.cc/66dLCZX0/4.png",])
 
     const [productInfo,setProductInfo] = useState([{}])
-    
+
     return(
     <div>
         <div>


### PR DESCRIPTION
구매자 계정 외 다른 계정으로 상품 상세 페이지 접근시
좋아요 버튼에 하트가 꽉 찬 하트로 표시되는 현상을 수정하고
만약 버튼을 클릭하면 구매자 계정으로만 가능한 기능이라는 안내메세지가 출력되도록 함

 Issues #39

# 🚀 개요
<!-- 상품상세 페이지 좋아요 아이콘 수정 -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 변경사항 1 구매자 계정 외 계정으로 좋아요 버튼 클릭시 안내메세지 출력
- 변경사항 2 구매자 계정 외 게정으로 상품상세 페이지 접근시 빈하트 표시
- 변경사항 3

## ⏳ 작업 내용
- [x] 작업 내용 1 구매자 계정으로만 좋아요 버튼을 누를수 있도록 수정함
- [x] 작업 내용 2 구매자 계정 외 계정으로 상품상세 페이지 접근시 빈 하트 표시되도록 수정함
- [ ] 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
