### PR TITLE
feature : 형상관리 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-bootstrap": "^2.10.0",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.2.1",
         "react-modal": "^3.16.1",
         "react-router-dom": "^6.22.3",
         "react-select": "^5.8.0",
@@ -17716,6 +17717,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-bootstrap": "^2.10.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.2.1",
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.22.3",
     "react-select": "^5.8.0",

--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,8 @@ import MyPages from "./pages/mypage.js";
 import Main from "./pages/main.js";
 import DesignerWriteEstimate from "./component/DesignerWriteEstimate.js";
 import PurchaserReformInfo from "./pages/PurchaserReformInfo.js";
+import ConfigurationManagement from './pages/designerConfigurationManagement.js'
+
 
 const App = () => {
   const [selectedTab, setSelectedTab] = useState(1);
@@ -118,6 +120,10 @@ const App = () => {
             path="/Mypage/Designer/Estimate/:requestNumber"
             element={<DesignerWriteEstimate />}
           ></Route>
+
+          <Route
+            path = 'ConfigurationManagement/:estimateId'
+            element = {<ConfigurationManagement/>}></Route>
         </Routes>
       </div>
     </div>

--- a/src/pages/DesignerMypage.js
+++ b/src/pages/DesignerMypage.js
@@ -31,6 +31,7 @@ export function DesignerMypage() {
   const [chatOpen, setChatOpen] = useState(false);
   const [messageData, setMessageData] = useState([]);
   const [status, setStatus] = useState("");
+  const estimateId = [];
 
   const headers = {
     Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
@@ -105,8 +106,10 @@ export function DesignerMypage() {
           },
         }
       );
-      window.location.reload();
     } catch (error) {}
+    finally{
+      fetchRequestReform();
+    }
   };
 
   const fetchRoomData = async (requestNumber) => {
@@ -195,7 +198,7 @@ export function DesignerMypage() {
   }, [chatInfo, roomExist]);
 
   const connect = () => {
-    const socket = new SockJS("");
+    const socket = new SockJS("석수동");
     const stompClient = Stomp.over(socket);
 
     if (stompClient && stompClient.connected) {
@@ -286,7 +289,7 @@ export function DesignerMypage() {
     } catch (error) {}
   };
 
-  const fetchEstimateData = async (requestNumber) => {
+  const fetchEstimateData = async (requestNumber,Id) => {
     try {
       const response = await axiosInstance.get(
         `/estimate/designer/estimateForm/${requestNumber}`,
@@ -298,7 +301,7 @@ export function DesignerMypage() {
       );
       const data = response.data.data;
       const R = data.estimateStatus;
-      console.log(R);
+      estimateId[Id]= data.estimateNumber
       return R;
     } catch (error) {
       throw new Error("오류로 견적서 내용을 불러오지 못했습니다.");
@@ -322,6 +325,11 @@ export function DesignerMypage() {
     }
   }, [connected, messageData]);
 
+  if(!requestReform){
+    return(
+      <div>이미지 로드중</div>
+    )
+  }
   return (
     <div>
       <TopBar />
@@ -458,6 +466,9 @@ export function DesignerMypage() {
                       alt="Request Image"
                       className="w-full h-auto mb-2"
                       style={{ maxHeight: "200px", maxWidth: "200px" }}
+                      onLoad = {() => fetchEstimateData(
+                        reform.requestNumber,index
+                      )}
                     />
                     <Typography variant="body" color="blue-gray">
                       요청 정보: {reform.requestInfo}
@@ -540,6 +551,24 @@ export function DesignerMypage() {
                         >
                           견적서 제출
                         </button>
+                        <button
+                          onClick = {() => {
+                            {estimateId[index]?
+                            navigate(`/ConfigurationManagement/${estimateId[index]}`):
+                            alert('아직 의뢰 요청이 수락되지 않았습니다.')}
+                          }}
+                          style={{
+                            backgroundColor: "darkblue",
+                            color: "white",
+                            padding: "8px 16px",
+                            border: "none",
+                            marginLeft: "8px",
+                            borderRadius: "4px",
+                            cursor: "pointer",
+                          }}
+                        >
+                          진행상황 공유
+                        </button>
                       </div>
                     ) : null}
                     {reform.requestStatus !== "REQUEST_ACCEPTED" &&
@@ -559,6 +588,7 @@ export function DesignerMypage() {
                           <option value="거절">리폼 거절</option>
                         </select>
                       )}
+                      <hr></hr>
                   </div>
                 ))}
             </CardBody>

--- a/src/pages/PurchaserMyPage.js
+++ b/src/pages/PurchaserMyPage.js
@@ -85,7 +85,23 @@ function CustomerOrderList() {
 
     fetchOrderList();
     fetchProducts();
+    test();
   }, []);
+
+  
+    const test = async () => {
+      try{
+        const fetchData = await axiosInstance.get(`/progress/img/1`,{
+          headers: {
+            "Content-Type": "multipart/form-data",
+            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+          },
+        });
+        console.log(fetchData)
+      }catch(err){
+
+      }
+    }
 
   const handleShowMore = () => {
     setShowMore(true);
@@ -236,6 +252,7 @@ function CustomerOrderList() {
   useEffect(() => {
     if (connected) {
       const fetchDataInterval = setInterval(() => {
+
         fetchMessageData();
       }, 1000); // 1초마다 데이터를 불러옴
 
@@ -244,7 +261,7 @@ function CustomerOrderList() {
   }, [connected, messageData]);
 
   const connect = () => {
-    const socket = new SockJS("");
+    const socket = new SockJS("석수동");
     const stompClient = Stomp.over(socket);
 
     if (stompClient && stompClient.connected) {
@@ -300,7 +317,7 @@ function CustomerOrderList() {
     }
   };
 
-  const fetchEstimateData = async (requestNumber) => {
+  const fetchEstimateData = async (requestNumber, event) => {
     try {
       const response = await axiosInstance.get(
         `/estimate/purchaser/estimateForm/${requestNumber}`,
@@ -314,7 +331,10 @@ function CustomerOrderList() {
       setEstimateNumber(data.estimateNumber);
       setRequestNumberEstimate(data.requestNumber);
 
-      if (data !== null) {
+      if(!event){
+        return response;
+      }
+      else if (data !== null) {
         const popupWindow = window.open(`estimateNumber`, `estimateNumber`, "width=600,height=400");
         popupWindow.document.write(`
         <h1>제출된 견적서</h1>
@@ -370,7 +390,7 @@ function CustomerOrderList() {
     disconnectWebSocket();
     setChatOpen(false);
   };
-
+  
   return (
     <div>
       <TopBar />
@@ -427,6 +447,7 @@ function CustomerOrderList() {
                 <img
                   src={`${product.requestImg[0].imgUrl}`}
                   alt={product.name}
+                  onLoad = {() => {fetchEstimateData(product.id)}}
                 />
                 <p>요청부위 : {product.requestPart}</p>
                 <p>요청사항 : {product.requestInfo}</p>
@@ -436,8 +457,8 @@ function CustomerOrderList() {
                   견적서 확인 : {product.state}{" "}
                   <button
                     className="OrderedBTN"
-                    onClick={() => {
-                      fetchEstimateData(product.id);
+                    onClick={(event) => {
+                      fetchEstimateData(product.id,event);
                     }}
                   >
                     자세히
@@ -474,6 +495,13 @@ function CustomerOrderList() {
                     }}
                   >
                     시작
+                  </button>
+                </p>
+
+                <p>
+                  리폼 현황 : 
+                  <button onClick = {() => {navigate(`/ConfigurationManagement/${estimateNumber}`)}} className="OrderedBTN">
+                    자세히
                   </button>
                 </p>
                 <hr></hr>

--- a/src/pages/designerConfigurationManagement.js
+++ b/src/pages/designerConfigurationManagement.js
@@ -1,0 +1,194 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axiosInstance from "../component/jwt.js";
+import TopBar from '../component/TopBar.js';
+import { Carousel } from 'antd';
+import { PhotoIcon } from '@heroicons/react/24/solid'
+import { CiCirclePlus } from "react-icons/ci";
+
+function ConfigurationManagement(){
+    let {estimateId} = useParams();
+    const [beforeImage, setBeforeImage] = useState();
+    const [firstImage, setFirstImage] = useState();
+    const [secondImage, setSecondImage] = useState();
+    const [lastImage, setLastImage] = useState();
+    const [imagePostStatus, setImagePostStatus] = useState(0);
+    const Endpoint = 'https://jjs-stock-bucket.s3.ap-northeast-2.amazonaws.com/'
+
+    const contentStyle = {
+        height: '200px', 
+        width: '100%', 
+        color: '#fff',
+        background: 'white',
+    };
+
+    let carouselImage = ([
+        "https://i.postimg.cc/jd4cY735/3.png",
+        "https://i.postimg.cc/zv1C9znK/1.png",
+        "https://i.postimg.cc/JnX36DBR/2.png",
+        "https://i.postimg.cc/66dLCZX0/4.png",])
+
+
+        useEffect(() => {
+            const fetchData = async () => {
+                try {
+                    const response = await axiosInstance.get(`/progress/img/${estimateId}`, {
+                        headers: {
+                            "Content-Type": "multipart/form-data",
+                            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+                        },
+                    });
+                    console.log('Fetched data:', response.data);
+                    setBeforeImage(response.data.data.productImgUrl);
+                    setFirstImage(response.data.data.firstImgUrl);
+                    setSecondImage(response.data.data.secondImgUrl);
+                    setLastImage(response.data.data.completeImgUrl);
+                } catch (err) {
+                    console.error('Error fetching data:', err);
+                }
+            };
+            fetchData();
+        }, [estimateId, imagePostStatus]);
+    
+        const handleImageUpload = async (url, formdata) => {
+            try {
+                await axiosInstance.patch(url, formdata, {
+                    headers: {
+                        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+                    },
+                });
+                setImagePostStatus(prevStatus => prevStatus + 1);
+            } catch (err) {
+                console.error('Error uploading image:', err);
+            }
+        };
+    
+        const firstImageHandler = (e) => {
+            const formdata = new FormData();
+            const files = e.target.files;
+            formdata.append('estimateId', estimateId);
+            formdata.append('imgUrl', files[0]);
+            handleImageUpload(`/progress/designer/setImg/first`, formdata);
+        };
+    
+        const secondImageHandler = (e) => {
+            const formdata = new FormData();
+            const files = e.target.files;
+            formdata.append('estimateId', estimateId);
+            formdata.append('imgUrl', files[0]);
+            handleImageUpload(`/progress/designer/setImg/second`, formdata);
+        };
+    
+        const reformCompletedHandler = (e) => {
+            const formdata = new FormData();
+            const files = e.target.files;
+            formdata.append('estimateId', estimateId);
+            formdata.append('imgUrl', files[0]);
+            handleImageUpload(`/progress/designer/setImg/complete`, formdata);
+        };
+
+    return (
+        <>
+            <TopBar />
+            <div className='ConfigurationManagementContainer' style = {{margin : '0 10% 0 20%'}}>
+                <div className = 'beforeImage' style = {{marginLeft : '15%'}}>
+                    <h4>리폼 전 이미지</h4>
+                    <img src = {Endpoint + beforeImage} height = '300px' width = '77%'></img>
+                </div>
+
+                <div className = 'beforeImage' style = {{margin : '10% 20% 0 15%'}}>
+                    {localStorage.getItem('role') == 'ROLE_DESIGNER' ? 
+                    <div style = {{display : 'flex', marginBottom : '1%'}}>
+                        <h4>첫번째 리폼</h4>
+                        <label
+                        style = {{marginLeft : 'auto'}}
+                        htmlFor="beforeReformImage-upload"
+                        className="relative cursor-pointer rounded-md bg-white font-semibold text-indigo-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-600 focus-within:ring-offset-2 hover:text-indigo-500"
+                        >
+                        <span>Upload a file</span>
+                        <input type="file" id="beforeReformImage-upload" multiple className="sr-only" onChange={(event) => firstImageHandler(event)} style={{display: "none", marginLeft : 'auto'}} />
+                        </label>
+                    </div>:
+                    <div style = {{display : 'flex', marginBottom : '1%'}}>
+                        <h4>첫번째 리폼</h4>
+                    </div>}
+                        {firstImage ?
+                        <div><img src={firstImage} style={{ width: '100%', height: '300px', textAlign: 'center' }} /></div>:
+                        <div>
+                            <PhotoIcon className="mx-auto h-15 w-15 text-gray-300" aria-hidden="true" />
+                        </div>
+                        }
+                </div>
+               
+                <div className = 'secondImage' style = {{margin : '10% 20% 0 15%'}}>
+                    {localStorage.getItem('role') == 'ROLE_DESIGNER' ? 
+                    <div style = {{display : 'flex', marginBottom : '1%'}}>
+                        <h4>두번째 리폼</h4>
+                        <label
+                        style = {{marginLeft : 'auto'}}
+                        htmlFor="secondReformImage-upload"
+                        className="relative cursor-pointer rounded-md bg-white font-semibold text-indigo-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-600 focus-within:ring-offset-2 hover:text-indigo-500"
+                        >
+                        <span>Upload a file</span>
+                        <input type="file" id="secondReformImage-upload" 
+                        multiple 
+                        className="sr-only" 
+                        onClick={(event) => {
+                        if(!firstImage){
+                        alert('첫번째 사진을 먼저 업로드 해주세요'); 
+                        event.preventDefault(); }}} 
+                        onChange={(event) => secondImageHandler(event)} 
+                        style={{display: "none", marginLeft : 'auto'}} />
+                        </label>
+                    </div>:
+                    <div style = {{display : 'flex', marginBottom : '1%'}}>
+                        <h4>두번째 리폼</h4>
+                    </div>}
+                        {secondImage ?
+                        <div><img src={secondImage} style={{ width: '100%', height: '300px', textAlign: 'center' }} /></div>:
+                        <div>
+                            <PhotoIcon className="mx-auto h-15 w-15 text-gray-300" aria-hidden="true" />
+                        </div>
+                        }
+                </div>
+                    
+                <div className = 'reformCompletedContainer' style = {{margin : '10% 20% 0 15%'}}>
+                    {localStorage.getItem('role') == 'ROLE_DESIGNER' ? 
+                        <div style = {{display : 'flex', marginBottom : '1%'}}>
+                            <h4>리폼 완료</h4>
+                            <label
+                            style = {{marginLeft : 'auto'}}
+                            htmlFor="reformCompletedImage"
+                            className="relative cursor-pointer rounded-md bg-white font-semibold text-indigo-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-600 focus-within:ring-offset-2 hover:text-indigo-500"
+                            >
+                            <span>Upload a file</span>
+                            <input type="file" id="reformCompletedImage" multiple 
+                                onClick={(event) => {
+                                if(!secondImage || !firstImage){
+                                alert('중간 사진을 먼저 업로드 해주세요'); 
+                                event.preventDefault();}}} 
+                                onChange={(event) => {
+                                    reformCompletedHandler(event);
+                                }}
+                                className="sr-only" 
+                                style={{display: "none", marginLeft : 'auto'}} />
+                            </label>
+                        </div>:
+                        <div style = {{display : 'flex', marginBottom : '1%'}}>
+                            <h4>리폼 완료</h4>
+                        </div>}
+                    {lastImage !== null ?
+                        <div>
+                            <img src={lastImage} style={{ width: '100%', height: '300px', textAlign: 'center' }}  />
+                        </div>:
+                        <div>
+                            <PhotoIcon className="mx-auto h-15 w-15 text-gray-300" aria-hidden="true" />
+                        </div>
+                    }
+                </div>         
+            </div>
+        </>
+    )
+}
+
+export default ConfigurationManagement;

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -110,7 +110,7 @@ function MainProduct(props){
 function CarouselC(props)
 {
     return(
-    <Carousel autoplay speed>
+    <Carousel autoplay speed = {5500}>
         {props.carouselImage.map((image, index) => (
         <div key={index}>
             <h3 style={props.carouselStyle}>

--- a/src/pages/mypage.js
+++ b/src/pages/mypage.js
@@ -21,7 +21,7 @@ function MyPages() {
 
   const productDeleteHandler = async (i) => {
     try {
-      const deleteProduct = await axiosInstance.delete(
+      const deleteProduct = await axiosInstance.patch(
         `/product/seller/register/${registerData[i].id}`,
         {
           headers: {


### PR DESCRIPTION
디자이너의 리폼 현황을 공유할 수 있는
형상관리 기능을 추가함

ISSUES #44

# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 변경사항 1 디자이너가 의뢰받은 옷의 리폼 현황을 공유해 줄 수 있음
- 변경사항 2 구매자는 디자이너가 공유해준 사진을 통해 의뢰맡긴 의류의 리폼 현황을 알 수 있음 
- 변경사항 3

## ⏳ 작업 내용
- [ ] 작업 내용 1 리폼현황 페이지 추가
- [ ] 작업 내용 2 디자이너가 의뢰받은 상품의 리폼 요청 수락 or 거절시 메뉴창에 상태가 변해야 하는데 기존 방식은 window.location을 이용한 페이지 새로고침이였지만 이를 수정해 수락 or 거절시 get요청을 다시 보내서 메뉴창의 상태가 변하게 만듬
- [ ] 작업 내용 3 

### 📝 논의사항
<!-- 백엔드쪽 문제로 중간중간 estimateNumber이 이상해 조회가 안되는 경우가 있음 + 디자이너는 아직 의뢰 확정이 안된 상품의 리폼현황을 들어가려고 하면 막히게 구현 해놨지만 구매자는 아직 미구현 상태-->
