### PR TITLE
디자이너의 작업물 등록 및 조회

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ import Main from "./pages/main.js";
 import DesignerWriteEstimate from "./component/DesignerWriteEstimate.js";
 import PurchaserReformInfo from "./pages/PurchaserReformInfo.js";
 import ConfigurationManagement from './pages/designerConfigurationManagement.js'
+import ReformCompleted from "./pages/reformComplete.js";
 
 
 const App = () => {
@@ -93,6 +94,8 @@ const App = () => {
           <Route path="/PurchaserReformInfo/:estimateNumber" element={<PurchaserReformInfo />}></Route>
 
           <Route path="/PurchaserMyPage" element={<PurchaserMyPage />}></Route>
+
+          <Route path = '/reformCompleted/:progressNumber' element = {<ReformCompleted/>}></Route>
 
           <Route
             path="/Mypage/PurchaserInfoEdit"

--- a/src/pages/DesignerMypage.js
+++ b/src/pages/DesignerMypage.js
@@ -31,6 +31,7 @@ export function DesignerMypage() {
   const [chatOpen, setChatOpen] = useState(false);
   const [messageData, setMessageData] = useState([]);
   const [status, setStatus] = useState("");
+  const [reformList, setReformList] = useState();
   const estimateId = [];
 
   const headers = {
@@ -92,6 +93,7 @@ export function DesignerMypage() {
     fetchRequestReform();
     fetchDesignerMypage();
     fetchDesignerPortfolio();
+    reformCompletedGet();
   }, []);
 
   const handleChangeStatus = async (requestId, newStatus) => {
@@ -325,7 +327,17 @@ export function DesignerMypage() {
     }
   }, [connected, messageData]);
 
-  if(!requestReform){
+  const reformCompletedGet = async () => {
+    try{
+      const completedResponse = await axiosInstance.get(`/portfolio/reformOutput/designer/list`)
+      setReformList(completedResponse.data.data)
+      console.log(completedResponse.data)
+    }catch(error){
+
+    }
+  }
+
+  if(!reformList){
     return(
       <div>이미지 로드중</div>
     )
@@ -392,17 +404,45 @@ export function DesignerMypage() {
               </>
             )}
           </Card>
-          <Card className="mx-auto mt-5 mb-6 border border-blue-gray-100  w-full max-w-[80rem]">
-            <div className="px-4 pb-4 mt-3">
+          
+          <Card className="mx-auto mt-5 mb-6 border border-blue-gray-100 items-center w-full max-w-[80rem]">
+            
               <Typography variant="h6" color="blue-gray" className="mb-2">
                 Projects
               </Typography>
-              <Typography
-                variant="small"
-                className="font-normal text-blue-gray-500"
-              >
-                Architects design
-              </Typography>
+                {reformList.map((element, index) => {
+                  return(
+                        <div key={index} className="mb-4" style = {{marginRight : '30%'}}>
+                        <img
+                          src={element.completeImgUrl}
+                          alt="Request Image"
+                          className="w-full h-auto mb-2"
+                          style={{ maxHeight: "200px", maxWidth: "200px" }}
+                        />
+                        <Typography color="blue-gray">
+                          리폼명 : {element.title}
+                          <button
+                          onClick={() => {
+                            navigate(``)
+                          }}
+                          style={{
+                            backgroundColor: "lightblue",
+                            color: "white",
+                            border: "none",
+                            borderRadius: "4px",
+                            cursor: "pointer",
+                            marginLeft : '9%'
+                          }}
+                        >
+                          자세히
+                        </button>
+                        </Typography>
+                        
+                        <hr></hr>
+                        </div>
+                  )
+                })}
+                
               <div className="mt-6 grid grid-cols-1 gap-12 md:grid-cols-2 xl:grid-cols-4">
                 {designerPortfolioResult.map((product) => (
                   <div
@@ -450,8 +490,9 @@ export function DesignerMypage() {
                   </div>
                 ))}
               </div>
-            </div>
+            
           </Card>
+          
           <Card className="mx-auto mt-5 mb-6 border border-blue-gray-100 items-center w-full max-w-[80rem]">
             <CardBody>
               <Typography variant="h6" color="blue-gray" className="mb-2">
@@ -470,13 +511,13 @@ export function DesignerMypage() {
                         reform.requestNumber,index
                       )}
                     />
-                    <Typography variant="body" color="blue-gray">
+                    <Typography color="blue-gray">
                       요청 정보: {reform.requestInfo}
                     </Typography>
-                    <Typography variant="body" color="blue-gray">
+                    <Typography color="blue-gray">
                       요청 부분: {reform.requestPart}
                     </Typography>
-                    <Typography variant="body" color="blue-gray">
+                    <Typography color="blue-gray">
                       요청 가격: {reform.requestPrice}
                     </Typography>
                     {reform.requestStatus !== "REQUEST_WAITING" ? (

--- a/src/pages/designerConfigurationManagement.js
+++ b/src/pages/designerConfigurationManagement.js
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import axiosInstance from "../component/jwt.js";
 import TopBar from '../component/TopBar.js';
-import { Carousel } from 'antd';
+import { useNavigate } from "react-router-dom";
 import { PhotoIcon } from '@heroicons/react/24/solid'
 import { CiCirclePlus } from "react-icons/ci";
+import axios from 'axios';
+import { progress } from '@material-tailwind/react';
 
 function ConfigurationManagement(){
     let {estimateId} = useParams();
@@ -13,21 +15,15 @@ function ConfigurationManagement(){
     const [secondImage, setSecondImage] = useState();
     const [lastImage, setLastImage] = useState();
     const [imagePostStatus, setImagePostStatus] = useState(0);
+    const [title, setTitle] = useState();
+    const [explanation, setExplanation] = useState();
     const Endpoint = 'https://jjs-stock-bucket.s3.ap-northeast-2.amazonaws.com/'
-
-    const contentStyle = {
-        height: '200px', 
-        width: '100%', 
-        color: '#fff',
-        background: 'white',
-    };
-
-    let carouselImage = ([
-        "https://i.postimg.cc/jd4cY735/3.png",
-        "https://i.postimg.cc/zv1C9znK/1.png",
-        "https://i.postimg.cc/JnX36DBR/2.png",
-        "https://i.postimg.cc/66dLCZX0/4.png",])
-
+    const [progressNumber, setProgressNumber] = useState();
+    const [check, setCheck] = useState();
+    let navigate = useNavigate();
+    const [isOpen, setIsOpen] = useState(false);
+    const openModal = () => setIsOpen(true);
+    const closeModal = () => setIsOpen(false);
 
         useEffect(() => {
             const fetchData = async () => {
@@ -39,6 +35,7 @@ function ConfigurationManagement(){
                         },
                     });
                     console.log('Fetched data:', response.data);
+                    setProgressNumber(response.data.data.progressId);
                     setBeforeImage(response.data.data.productImgUrl);
                     setFirstImage(response.data.data.firstImgUrl);
                     setSecondImage(response.data.data.secondImgUrl);
@@ -48,9 +45,10 @@ function ConfigurationManagement(){
                 }
             };
             fetchData();
+            
         }, [estimateId, imagePostStatus]);
-    
-        const handleImageUpload = async (url, formdata) => {
+
+        const imageUploadHandler = async (url, formdata) => {
             try {
                 await axiosInstance.patch(url, formdata, {
                     headers: {
@@ -68,7 +66,7 @@ function ConfigurationManagement(){
             const files = e.target.files;
             formdata.append('estimateId', estimateId);
             formdata.append('imgUrl', files[0]);
-            handleImageUpload(`/progress/designer/setImg/first`, formdata);
+            imageUploadHandler(`/progress/designer/setImg/first`, formdata);
         };
     
         const secondImageHandler = (e) => {
@@ -76,16 +74,62 @@ function ConfigurationManagement(){
             const files = e.target.files;
             formdata.append('estimateId', estimateId);
             formdata.append('imgUrl', files[0]);
-            handleImageUpload(`/progress/designer/setImg/second`, formdata);
+            imageUploadHandler(`/progress/designer/setImg/second`, formdata);
         };
     
-        const reformCompletedHandler = (e) => {
+        const lastImageHandler = (e) => {
             const formdata = new FormData();
             const files = e.target.files;
             formdata.append('estimateId', estimateId);
             formdata.append('imgUrl', files[0]);
-            handleImageUpload(`/progress/designer/setImg/complete`, formdata);
+            imageUploadHandler(`/progress/designer/setImg/complete`, formdata);
         };
+        
+        const reformCompletedHandler = async () => {
+            try{
+                const response = await axiosInstance.post(`/portfolio/reformOutput/upload/${progressNumber}`,{
+                    title : title,
+                    explanation : explanation 
+                })
+                console.log(response)
+            }finally{
+                closeModal()
+            }
+        }
+
+        //현재 progressNumber을 얻어올 수 있는 방법이 형상관리 api를 사용하는것 외에는 존재하지 않아서
+        //형상관리 페이지가 아닌 다른곳에서 디자이너가 자신이 작업한 작업물들만 모아서 조회하는것이 불가능함(로그인한 디자이너의 작업물 조회 api에도 타이틀하고 imgurl밖에없음)
+        //해서 부득이하게 형상관리 페이지에서 디자이너 작업물 열람으로 넘어가는 방식으로 구현을 할 수 밖에 없게됐고 
+        //형상관리 최종 사진을 등록하고 작업물 등록을 했는지 안했는지 확인할 수 있는 함수가 필요해서 만든게 reformCheck함수
+        //해당 함수를 통해 얻어오는 값에 따라서 리폼 등록 버튼 or 작업물 보러가기 버튼이 보임
+        const reformCheck = async() => {
+            try{
+                const response = await axiosInstance.get(`/portfolio/reformOutput/upload/${progressNumber}`)
+                setCheck(response.data.data)
+                console.log(check)
+            }catch(error){
+
+            }
+        }
+
+        useEffect(() => {
+            if (progressNumber) {
+              reformCheck();
+            }
+          }, [progressNumber]);
+
+        const titleUpdateHandler = (event) => {
+            setTitle(event.target.value)
+        }
+
+        const explanationUpdateHandler = (event) => {
+            setExplanation(event.target.value)
+        }
+
+
+        if(!check){
+            return(<div>데이터 로드중...</div>)
+        }
 
     return (
         <>
@@ -95,7 +139,7 @@ function ConfigurationManagement(){
                     <h4>리폼 전 이미지</h4>
                     <img src = {Endpoint + beforeImage} height = '300px' width = '77%'></img>
                 </div>
-
+                
                 <div className = 'beforeImage' style = {{margin : '10% 20% 0 15%'}}>
                     {localStorage.getItem('role') == 'ROLE_DESIGNER' ? 
                     <div style = {{display : 'flex', marginBottom : '1%'}}>
@@ -168,7 +212,7 @@ function ConfigurationManagement(){
                                 alert('중간 사진을 먼저 업로드 해주세요'); 
                                 event.preventDefault();}}} 
                                 onChange={(event) => {
-                                    reformCompletedHandler(event);
+                                    lastImageHandler(event);
                                 }}
                                 className="sr-only" 
                                 style={{display: "none", marginLeft : 'auto'}} />
@@ -185,8 +229,99 @@ function ConfigurationManagement(){
                             <PhotoIcon className="mx-auto h-15 w-15 text-gray-300" aria-hidden="true" />
                         </div>
                     }
-                </div>         
+                </div>       
+
+                <div className = 'reformCompleted-btn' style = {{margin : '5% 15% 3% 0',textAlign : 'right'}}>
+                    {!check ? 
+                    <button
+                    className="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border-1 border-blue-500 rounded-full"
+                    style={{ marginRight: "5%" }}
+                    onClick={openModal}
+                    >
+                    리폼 완료{" "}
+                    </button> : 
+                    <button
+                    className="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border-1 border-blue-500 rounded-full"
+                    style={{ marginRight: "5%" }}
+                    onClick = {()=>{
+                        navigate(`/reformCompleted/${progressNumber}`)
+                    }}>
+                    작업물 보기
+                    </button>}
+                    
+                </div>
+                <Modal isOpen = {isOpen} closeModal = {closeModal} reformCompletedHandler = {reformCompletedHandler} titleUpdateHandler = {titleUpdateHandler} explanationUpdateHandler = {explanationUpdateHandler}/>
             </div>
+        </>
+    )
+}
+
+function Modal(props){
+    return(
+        <>
+            {props.isOpen && (
+                <div id="default-modal" tabIndex="-1" aria-hidden="true" className="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+                <div className="relative p-4 w-full max-w-2xl max-h-full">
+                    <div className="relative bg-white rounded-lg shadow dark:bg-gray-700">
+                    <div className="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
+                        <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
+                        작업물 등록
+                        </h3>
+                        <button
+                        type="button"
+                        onClick={props.closeModal}
+                        className="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
+                        >
+                        <svg className="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+                        </svg>
+                        </button>
+                    </div>
+                    <div className="p-4 md:p-5 space-y-4">
+                        <p className="text-xl leading-relaxed text-gray-900 dark:text-gray-600">
+                        한번 등록한 작업물은 제목과 설명을 제외하고는 수정이 불가합니다.
+                        </p>
+                        <div> 
+                            <input 
+                            type="text" 
+                            name="title" 
+                            id="title" 
+                            className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white" 
+                            placeholder="제목을 입력해주세요"
+                            onChange = {(event) => {props.titleUpdateHandler(event)}}
+                            required /> 
+                        </div>
+                        <div> 
+                            <input 
+                            type="text" 
+                            name="explanation" 
+                            id="explanation" 
+                            className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white" 
+                            placeholder="리폼에 대한 설명을 입력해주세요"
+                            onChange = {(event) => {props.explanationUpdateHandler(event)}} 
+                            required /> 
+                        </div>
+                    </div>
+                    <div className="flex items-center p-4 md:p-5 border-t border-gray-200 rounded-b dark:border-gray-600">
+                        <button
+                        onClick = {() => {props.reformCompletedHandler()}}
+                        type="button"
+                        className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+                        >
+                        I accept
+                        </button>
+                        <button
+                        onClick={props.closeModal}
+                        type="button"
+                        className="py-2.5 px-5 ms-3 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700"
+                        >
+                        Decline
+                        </button>
+                    </div>
+                    </div>
+                </div>
+                </div>
+            )}
         </>
     )
 }

--- a/src/pages/mypage.js
+++ b/src/pages/mypage.js
@@ -95,7 +95,7 @@ function MyPages() {
     }
     setDeliveryState(newDeliveryState);
   }, [soldProduct]);
-
+  console.log(registerData)
   if (!sellerData) {
     return <div>데이터 로드중</div>;
   }

--- a/src/pages/reformComplete.js
+++ b/src/pages/reformComplete.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from 'react-router-dom';
+import axiosInstance from "../component/jwt.js";
+import TopBar from '../component/TopBar.js';
+
+import {
+    Card,
+    CardBody,
+    CardHeader,
+    CardFooter,
+    Typography,
+    Tooltip,
+  } from "@material-tailwind/react";
+
+function ReformCompleted(){
+    //형상관리 페이지에서 작업물로 이동하는걸로 해야할듯
+    const Endpoint = "https://jjs-stock-bucket.s3.ap-northeast-2.amazonaws.com/";
+    const [reformData, setReformData] = useState();
+
+    let {progressNumber} = useParams();
+    const style = {
+        height : '300px' , 
+        width : '300px',
+        margin : '2% 0 4% 1%'
+    }
+
+    const reformcompleted = async () => {
+        try{
+            const response = await axiosInstance.get(`/portfolio/reformOutput/detail/${progressNumber}`,
+            )
+            setReformData(response.data.data)
+            console.log(response.data.data)
+        }catch(error){
+            console.error('에러',error)
+        }
+    }
+
+    useEffect(() => {
+        if (progressNumber) {
+        reformcompleted()
+        }
+    },[progressNumber])
+
+    console.log(progressNumber)
+
+    if(!reformData){
+        return(
+            <div>데이터 로드중...</div>
+        )
+    }
+
+    return(
+        <>
+            <TopBar />
+            <div className = 'reformCompleted-Container'>
+                <Card>
+                    <Typography variant="h6" color="blue-gray" className="mt-2 ml-8">
+                        의뢰 상품
+                    </Typography>
+                    <CardHeader className = 'mb-5'>
+                            <img src = {Endpoint + reformData.productImgUrl} style = {style}></img>
+                    </CardHeader>
+
+                    <Typography variant="h6" color="blue-gray" className="mt-2 ml-8">
+                        고객 요청
+                    </Typography>
+                    <CardHeader>
+                        <img src = {reformData.reformRequestImgUrl} style = {style}></img>
+                    </CardHeader>
+                    
+                    <Typography variant="h6" color="blue-gray" className="mt-2 ml-8">
+                        디자이너 예상 
+                    </Typography>
+                    <CardHeader>
+                        <img src = {reformData.estimateImgUrl} style = {style}></img>
+                    </CardHeader>
+
+                    <Typography variant="h6" color="blue-gray" className="mt-2 ml-8">
+                        리폼 후 
+                    </Typography>
+                    <CardHeader>
+                        <img src = {reformData.completeImgUrl} style = {style}></img>
+                    </CardHeader>
+                </Card>
+            </div>
+                
+         </>
+    )
+}
+
+export default ReformCompleted;


### PR DESCRIPTION
디자이너가 리폼이 끝난 상품을 자신의 포트폴리오(작업물)로
등록하고 이를 조회할 수 있음

ISSUES #47

# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 변경사항 1 리폼 완료한 작업물을 자신의 포트폴리오로 등록 가능
- 형상관리 페이지에서 작업물 등록 버튼 클릭시 등록버튼 대신 작업물을 열람할 수 있는 버튼으로 바뀜


### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
