### PR TITLE
fix : postRefreshToken 함수 수정

### DIFF
--- a/src/component/jwt.js
+++ b/src/component/jwt.js
@@ -41,7 +41,6 @@ export const postRefreshToken = async () => {
   localStorage.setItem('refreshToken', response.data.data.refreshToken);
   document.cookie ='accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
   document.cookie = `accessToken=${response.data.data.accessToken}; Path=/;`;
-  console.log(localStorage.getItem('accessToken'))
   return response
 }
 


### PR DESCRIPTION
>>
>> 기존 엑세스 토큰이 만료돼도 재발급이 되지 않던 문제를 해결함
>> 토큰 저장 방식을 localstorage에서 zustand를 통한 localstorage로 변경
>>
>> # Issues 70

# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
postRefreshToken 함수 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 변경사항 1 토큰 저장 방식 변경
- 변경사항 2 쿠키 저장 방식 변경
- 변경사항 3 엑세스 토큰 만료시 리프레시 토큰을 통해 토큰 재발급 됨

## ⏳ 작업 내용
- [ ] 작업 내용 1
- [ ] 작업 내용 2
- [ ] 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
